### PR TITLE
release 1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2
+jobs:
+
+  build:
+    docker:
+    - image: circleci/golang:latest
+      environment:
+        GO111MODULE: 'on'
+    working_directory: /go/src/github.com/koron/go-dproxy
+    steps:
+    - run: go version && go env
+    - checkout
+    - run: go get -v -t -d ./...
+    - run: go test -v ./...
+
+  build+module:
+    docker:
+    - image: circleci/golang:latest
+      environment:
+        GO111MODULE: 'on'
+    working_directory: /go/src/github.com/koron/go-dproxy
+    steps:
+    - run: go version && go env
+    - checkout
+    - run:
+        name: install latest git
+        command: |
+          echo "deb http://ftp.debian.org/debian stretch-backports main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get -t stretch-backports install -y git
+    - restore_cache:
+        keys:
+        - module-v1-{{ .Branch }}-{{ checksum "go.sum" }}
+        - module-v1-{{ .Branch }}-
+        - module-v1-
+    - run: go test -v ./...
+    - save_cache:
+        key: module-v1-{{ .Branch }}-{{ checksum "go.sum" }}
+        paths:
+        - /go/pkg/mod/cache
+
+workflows:
+  version: 2
+  build-all:
+    jobs:
+    - build
+    - build+module

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # dProxy - document proxy
 
 [![GoDoc](https://godoc.org/github.com/koron/go-dproxy?status.svg)](https://godoc.org/github.com/koron/go-dproxy)
+[![CircleCI](https://img.shields.io/circleci/project/github/koron/go-dproxy/master.svg)](https://circleci.com/gh/koron/go-dproxy/tree/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/koron/go-dproxy)](https://goreportcard.com/report/github.com/koron/go-dproxy)
 
 dProxy is a proxy to access `interface{}` (document) by simple query.

--- a/frame.go
+++ b/frame.go
@@ -12,6 +12,9 @@ func fullAddress(f frame) string {
 	for g := f; g != nil; g = g.parentFrame() {
 		x += len(g.frameLabel())
 	}
+	if x == 0 {
+		return "(root)"
+	}
 	b := make([]byte, x)
 	for g := f; g != nil; g = g.parentFrame() {
 		x -= len(g.frameLabel())

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/koron/go-dproxy
+
+go 1.13

--- a/package_test.go
+++ b/package_test.go
@@ -7,8 +7,19 @@ import (
 )
 
 func assertEquals(t *testing.T, actual, expected interface{}, format string, a ...interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(actual, expected) {
 		msg := fmt.Sprintf(format, a...)
-		t.Errorf("not equal: %s\nactual=%+v\nexpected=%+v", msg, actual, expected)
+		t.Errorf("not equal: %s\nexpect=%+v\nactual=%+v", msg, expected, actual)
+	}
+}
+
+func assertError(t *testing.T, err error, exp string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("should fail with: %s", exp)
+	}
+	if act := err.Error(); act != exp {
+		t.Fatalf("unexpected error:\nexpect=%s\nactual=%s\n", exp, act)
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -93,3 +93,18 @@ func TestMapBool(t *testing.T) {
 		t.Errorf("bar must be false")
 	}
 }
+
+type wrappedMap map[string]interface{}
+
+func TestWrappedMap(t *testing.T) {
+	v := wrappedMap{
+		"foo": 123,
+	}
+	n, err := New(v).M("foo").Int64()
+	if err != nil {
+		t.Fatalf("failed: %s", err)
+	}
+	if n != 123 {
+		t.Fatalf("unexpected value: %d", n)
+	}
+}

--- a/value.go
+++ b/value.go
@@ -132,7 +132,7 @@ func (p *valueProxy) A(n int) Proxy {
 			label:  a,
 		}
 	default:
-		return typeError(p, Tarray, v)
+		return requiredTypeError(p, Tarray, v)
 	}
 }
 
@@ -150,7 +150,7 @@ func (p *valueProxy) M(k string) Proxy {
 			label:  a,
 		}
 	default:
-		return typeError(p, Tmap, v)
+		return requiredTypeError(p, Tmap, v)
 	}
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,33 @@
+package dproxy
+
+import "testing"
+
+func TestTypeError(t *testing.T) {
+	t.Run("map at root", func(t *testing.T) {
+		v := &valueProxy{}
+		_, err := v.M("foo").Int64()
+		assertError(t, err, "not required types: required=map actual=nil: (root)")
+	})
+	t.Run("map at child", func(t *testing.T) {
+		v := &valueProxy{
+			parent: &valueProxy{},
+			label:  "foo",
+		}
+		_, err := v.M("bar").Int64()
+		assertError(t, err, "not required types: required=map actual=nil: foo")
+	})
+
+	t.Run("array at root", func(t *testing.T) {
+		v := &valueProxy{}
+		_, err := v.A(0).Int64()
+		assertError(t, err, "not required types: required=array actual=nil: (root)")
+	})
+	t.Run("array at child", func(t *testing.T) {
+		v := &valueProxy{
+			parent: &valueProxy{},
+			label:  "foo",
+		}
+		_, err := v.A(0).Int64()
+		assertError(t, err, "not required types: required=array actual=nil: foo")
+	})
+}


### PR DESCRIPTION
improve `M()` behaviors.

* `M()` at root for wrong type, causes panic when call `Error()`
* `M()` doesn't work on `type WrappedType map[string]interface{}`